### PR TITLE
fix: add file type so that `FilePreview` used in `ChatMessage` renders correctly

### DIFF
--- a/apps/www/registry/default/ui/chat-message.tsx
+++ b/apps/www/registry/default/ui/chat-message.tsx
@@ -104,7 +104,7 @@ export const ChatMessage: React.FC<ChatMessageProps> = ({
   const files = useMemo(() => {
     return experimental_attachments?.map((attachment) => {
       const dataArray = dataUrlToUint8Array(attachment.url)
-      const file = new File([dataArray], attachment.name ?? "Unknown")
+      const file = new File([dataArray], attachment.name ?? "Unknown", {type: attachment.contentType})
       return file
     })
   }, [experimental_attachments])


### PR DESCRIPTION
Without the file type, `FilePreview` always defaults to rendering `GenericFilePreview`.