### PR TITLE
Deprecation noitice for isLoading, replace  with status

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,11 @@ import { useChat } from "ai/react"
 import { Chat } from "@/components/ui/chat"
 
 export function ChatDemo() {
-  const { messages, input, handleInputChange, handleSubmit, isLoading, stop } =
+  const { messages, input, handleInputChange, handleSubmit, status, stop } =
     useChat()
+
+
+  const isLoading = status === 'submitted' || status === 'streaming'
 
   return (
     <Chat

--- a/apps/www/content/docs/components/chat.mdx
+++ b/apps/www/content/docs/components/chat.mdx
@@ -77,8 +77,10 @@ import { useChat } from "ai/react"
 import { Chat } from "@/components/ui/chat"
 
 export function ChatDemo() {
-  const { messages, input, handleInputChange, handleSubmit, isLoading, stop } =
+  const { messages, input, handleInputChange, handleSubmit, status, stop } =
     useChat()
+
+  const isLoading = status === 'submitted' || status === 'streaming'
 
   return (
     <Chat
@@ -109,9 +111,11 @@ export function ChatWithSuggestions() {
     handleInputChange,
     handleSubmit,
     append,
-    isLoading,
+    status,
     stop,
   } = useChat()
+
+  const isLoading = status === 'submitted' || status === 'streaming'
 
   return (
     <Chat
@@ -153,10 +157,11 @@ export function CustomChat() {
     handleInputChange,
     handleSubmit,
     append,
-    isLoading,
+    status,
     stop,
   } = useChat()
 
+  const isLoading = status === 'submitted' || status === 'streaming'
   const lastMessage = messages.at(-1)
   const isEmpty = messages.length === 0
   const isTyping = lastMessage?.role === "user"

--- a/apps/www/registry/default/example/chat-demo.tsx
+++ b/apps/www/registry/default/example/chat-demo.tsx
@@ -25,7 +25,6 @@ type ChatDemoProps = {
 
 export default function ChatDemo(props: ChatDemoProps) {
   const [selectedModel, setSelectedModel] = useState(MODELS[0].id)
-
   const {
     messages,
     input,
@@ -33,7 +32,7 @@ export default function ChatDemo(props: ChatDemoProps) {
     handleSubmit,
     append,
     stop,
-    isLoading,
+    status,
     setMessages,
   } = useChat({
     ...props,
@@ -42,6 +41,8 @@ export default function ChatDemo(props: ChatDemoProps) {
       model: selectedModel,
     },
   })
+
+  const isLoading = status === "submitted" || status === "streaming"
 
   return (
     <div className={cn("flex", "flex-col", "h-[500px]", "w-full")}>


### PR DESCRIPTION
Deprecation notice for `isLoading`, in documentation and demo, replaced `isLoading` with `status`, checking for both:
- submitted
- streaming